### PR TITLE
fix: stop hookをPostToolUseに変更し無限ループを解消

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -93,8 +93,9 @@
         ]
       }
     ],
-    "Stop": [
+    "PostToolUse": [
       {
+        "matcher": "Edit|Write",
         "hooks": [
           {
             "type": "command",

--- a/.config/wezterm/wezterm.lua
+++ b/.config/wezterm/wezterm.lua
@@ -2,10 +2,12 @@ local wezterm = require("wezterm")
 local config = wezterm.config_builder()
 
 config.automatically_reload_config = true
+config.font = wezterm.font("JetBrainsMono Nerd Font")
 config.font_size = 12.0
 config.use_ime = true
 config.window_background_opacity = 0.75
 config.macos_window_background_blur = 20
+config.color_scheme = "Catppuccin Mocha"
 
 ----------------------------------------------------
 -- Tab


### PR DESCRIPTION
## Summary
- Stop hookがClaudeの応答終了時に毎回発火し、無限ループになる問題を修正
- `Stop` → `PostToolUse` に変更し、`Edit|Write`ツール使用後のみ発火するように
- wezterm設定にフォントとカラースキームを追加

## 変更内容
### Hook修正
- `git diff HEAD`は変更がコミットされるまで同じファイルを検出し続けるため、Stop hookでは毎回発火していた
- PostToolUseに変更し、ファイル編集ツールの後のみ発火させることで解決

### WezTerm設定
- `JetBrainsMono Nerd Font` を追加
- `Catppuccin Mocha` カラースキームを追加

## Test plan
- [x] Claude Codeで通常の会話をしてhookが発火しないことを確認
- [x] Edit/Writeツール使用後にhookが発火することを確認
- [x] 無限ループが発生しないことを確認