### PR TITLE
feat: add WezTerm status bar and cursor customization

### DIFF
--- a/.config/wezterm/wezterm.lua
+++ b/.config/wezterm/wezterm.lua
@@ -38,11 +38,16 @@ config.show_new_tab_button_in_tab_bar = false
 -- タブの閉じるボタンを非表示
 config.show_close_tab_button_in_tabs = false
 
--- タブ同士の境界線を非表示
+-- タブ同士の境界線を非表示、背景を透過
 config.colors = {
   tab_bar = {
+    background = "rgba(0,0,0,0)",
     inactive_tab_edge = "none",
   },
+  cursor_bg = "#cba6f7",
+  cursor_fg = "#1e1e2e",
+  cursor_border = "#cba6f7",
+  compose_cursor = "#f38ba8",
 }
 
 -- タブの形をカスタマイズ


### PR DESCRIPTION
## Summary
- ステータスバー追加（バッテリー、日時、LEADER表示）
- カーソル色のカスタマイズ（通常時: mauve、LEADER時: pink）
- タブバー背景の透過設定

## Test plan
- [x] WezTermを再起動して設定が反映されることを確認
- [x] バッテリー残量と時刻が右側に表示される
- [x] `Ctrl+q`でLEADERを押すとカーソルがピンクに変わる
- [x] タブバー背景が透過している