### PR TITLE
fix: remove Option+Enter fullscreen keybind from WezTerm

### DIFF
--- a/.config/wezterm/keybinds.lua
+++ b/.config/wezterm/keybinds.lua
@@ -61,9 +61,6 @@ return {
     { key = "w", mods = "SUPER", action = act({ CloseCurrentTab = { confirm = true } }) },
     { key = "}", mods = "LEADER", action = act({ MoveTabRelative = 1 }) },
 
-    -- 画面フルスクリーン切り替え
-    { key = "Enter", mods = "ALT", action = act.ToggleFullScreen },
-
     -- コピーモード
     -- { key = 'X', mods = 'LEADER', action = act.ActivateKeyTable{ name = 'copy_mode', one_shot =false }, },
     { key = "[", mods = "LEADER", action = act.ActivateCopyMode },


### PR DESCRIPTION
## Summary

- WezTermのキーバインド設定から、Option+Enter（ALT+Enter）による全画面切り替え機能を削除

## 変更内容

`.config/wezterm/keybinds.lua` から以下の設定を削除:
```lua
{ key = "Enter", mods = "ALT", action = act.ToggleFullScreen }
```

## Test plan

- [x] WezTermを再起動し、Option+Enterで全画面に切り替わらないことを確認