### PR TITLE
feat: add context7 plugin to Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -102,7 +102,8 @@
     "frontend-design@claude-code-plugins": true,
     "commit-commands@claude-code-plugins": true,
     "typescript-lsp@claude-plugins-official": true,
-    "feature-dev@claude-code-plugins": true
+    "feature-dev@claude-code-plugins": true,
+    "context7@claude-plugins-official": true
   },
   "feedbackSurveyState": {
     "lastShownTime": 1754137712092


### PR DESCRIPTION
## Summary
- Claude Code の設定に context7 プラグインを追加

## 変更内容
- `.claude/settings.json` に `context7@claude-plugins-official` プラグインを有効化