### PR TITLE
fix: update Telescope to use master branch for Neovim 0.11 compatibility

### DIFF
--- a/.config/nvim/lua/plugins/telescope.lua
+++ b/.config/nvim/lua/plugins/telescope.lua
@@ -4,7 +4,7 @@
 return {
   {
     "nvim-telescope/telescope.nvim",
-    tag = "0.1.8",
+    branch = "master",
     dependencies = {
       "nvim-lua/plenary.nvim",
       {


### PR DESCRIPTION
## Summary

- Telescope 0.1.8 uses deprecated `vim.treesitter.language.ft_to_lang` API which was removed in Neovim 0.11
- This caused errors when using LSP references (`gr`) and other Telescope features with preview
- Switch from `tag = "0.1.8"` to `branch = "master"` to get the latest version with Neovim 0.11 support

## Test plan

- [x] Open Neovim and run `:Lazy sync`
- [x] Restart Neovim
- [x] Place cursor on a function and press `gr` to search references
- [x] Verify no errors appear and Telescope displays results correctly