### PR TITLE
feat: adjust wezterm window opacity

### DIFF
--- a/.config/wezterm/wezterm.lua
+++ b/.config/wezterm/wezterm.lua
@@ -6,7 +6,7 @@ config.enable_kitty_graphics = true -- image.nvim 用
 config.font = wezterm.font("JetBrainsMono Nerd Font")
 config.font_size = 12.5
 config.use_ime = true
-config.window_background_opacity = 0.75
+config.window_background_opacity = 0.45
 config.macos_window_background_blur = 20
 config.color_scheme = "Catppuccin Mocha"
 


### PR DESCRIPTION
## Summary
- WezTerm のウィンドウ透明度を 0.75 から 0.45 に変更
- より透明感のある見た目に調整

## Test plan
- WezTerm を再起動して透明度が変更されていることを確認