### PR TITLE
chore: remove obsolete claude alias from zshrc

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -9,7 +9,6 @@ export PATH="/Users/takumi0706/.codeium/windsurf/bin:$PATH"
 export PATH="/usr/local/bin:$PATH"
 export PATH="/opt/homebrew/Caskroom/flutter/3.29.3/flutter/bin:$PATH"
 export PATH="/Library/TeX/texbin:$PATH"
-alias claude="/Users/takumi0706/.claude/local/claude"
 
 [[ "$TERM_PROGRAM" == "kiro" ]] && . "$(kiro --locate-shell-integration-path zsh)"
 


### PR DESCRIPTION
## Summary
- 不要になった claude エイリアスを .zshrc から削除
- Claude Code は PATH に追加されているため、エイリアスは不要

## Test plan
- `source ~/.zshrc` 後、`claude` コマンドが正常に動作することを確認