### PR TITLE
refactor: convert bounded-context skill prompts to English

### DIFF
--- a/.claude/skills/bounded-context/SKILL.md
+++ b/.claude/skills/bounded-context/SKILL.md
@@ -14,62 +14,62 @@ allowed-tools:
   - WebFetch
 ---
 
-# DDD 境界付けられたコンテキスト分析スキル
+# DDD Bounded Context Analysis Skill
 
-## 背景思想
+## Background Philosophy
 
-### 言語ゲーム × DDD
+### Language Games × DDD
 
-ヴィトゲンシュタインは『哲学探究』第43節で「語の意味とは、言語におけるその使用である」と述べた。
-同じ単語でも、使われる文脈（誰が・何の目的で使うか）によって意味が変わる。この「言語ゲーム」の
-考え方は、DDDの「境界付けられたコンテキスト（Bounded Context）」と深く結びつく。
+In §43 of *Philosophical Investigations*, Wittgenstein stated: "The meaning of a word is its use in the language."
+The same word can have different meanings depending on the context — who uses it and for what purpose. This concept
+of "language games" is deeply connected to DDD's Bounded Context.
 
-**核心原則:** 「この言葉はどういう意味ですか？」ではなく「この言葉をどう使っていますか？」と問う。
+**Core principle:** Ask not "What does this word mean?" but "How is this word being used?"
 
-### @MinoDriven（仙塲大也）氏の手法
+### @MinoDriven (Daiya Seba) Approach
 
-アクターの**目的**を起点にコンテキスト境界を導出する:
+Derive context boundaries starting from the **purpose** of actors:
 
-- **第1層: アクター（Actor）** — 誰がシステムを使うか
-- **第2層: 目的（Purpose）** — アクターが何を達成したいか → 言語ゲームの「文脈」を決定
-- **第3層: ルール（Rule）** — 目的が異なれば同じ言葉でも適用されるルールが異なる
+- **Layer 1: Actor** — Who uses the system
+- **Layer 2: Purpose** — What the actor wants to achieve → determines the "context" of the language game
+- **Layer 3: Rules** — Different purposes lead to different rules applied to the same terms
 
-**1つのコンテキスト = [アクター, 目的, ルール群] のセット**
+**One context = a set of [Actor, Purpose, Rules]**
 
 ---
 
-## 実行手順
+## Execution Steps
 
-### Phase 1: ドメイン理解（入力収集）
+### Phase 1: Domain Understanding (Input Collection)
 
-**目標:** 分析対象のドメインを理解する。
+**Goal:** Understand the target domain.
 
-1. ユーザーに以下を確認する:
-   - 分析対象のシステム/ドメインの概要
-   - 既存のドキュメント（要件定義書、ユーザーストーリー等）の有無
-   - 既存コードベースの有無
+1. Confirm with the user:
+   - Overview of the target system/domain
+   - Availability of existing documents (requirements, user stories, etc.)
+   - Availability of existing codebase
 
-2. 既存コードがある場合:
-   - ディレクトリ構造を調査（`Glob`, `Read`）
-   - ドメインモデル/エンティティを特定（`Grep` で主要クラス/型を検索）
-   - 既存の命名パターンを収集
+2. If existing code is available:
+   - Investigate directory structure (`Glob`, `Read`)
+   - Identify domain models/entities (`Grep` to search for key classes/types)
+   - Collect existing naming patterns
 
-3. ドメイン知識が不足している場合:
-   - `WebSearch` / `WebFetch` で業界用語や標準的なビジネスプロセスを調査
+3. If domain knowledge is insufficient:
+   - Research industry terms and standard business processes via `WebSearch` / `WebFetch`
 
-### Phase 2: アクターの特定
+### Phase 2: Actor Identification
 
-**目標:** システムに関わるすべてのアクターとその目的を列挙する。
+**Goal:** Enumerate all actors and their purposes.
 
-1. アクターを洗い出す:
-   - 人間のアクター（エンドユーザー、管理者、オペレーター等）
-   - システムアクター（外部システム、バッチ処理等）
+1. Discover actors:
+   - Human actors (end users, administrators, operators, etc.)
+   - System actors (external systems, batch processes, etc.)
 
-2. 各アクターの目的を定義する:
-   - 「〜として、〜のために、〜したい」形式で記述
-   - 1つのアクターが複数の目的を持つことがある → それぞれ別の言語ゲームになりうる
+2. Define each actor's purpose:
+   - Use the format: "As [actor], in order to [purpose], I want to [action]"
+   - One actor may have multiple purposes → each may constitute a different language game
 
-3. 出力形式:
+3. Output format:
 
 ```markdown
 | アクター | 目的 | 主要なアクション |
@@ -78,18 +78,18 @@ allowed-tools:
 | 出品者   | 商品を販売して利益を得る | 商品登録、在庫管理、売上確認 |
 ```
 
-### Phase 3: 言語ゲームの分析
+### Phase 3: Language Game Analysis
 
-**目標:** 同じ用語がアクター/目的によって異なる意味を持つポイントを発見する。
+**Goal:** Discover points where the same term has different meanings depending on actor/purpose.
 
-1. **用語収集:** Phase 2 で出てきた主要な名詞・動詞を一覧化する
+1. **Term collection:** List all major nouns and verbs from Phase 2
 
-2. **意味の分岐点を探す:** 各用語について以下を問う:
-   - この用語を使うアクターは誰か？
-   - そのアクターの目的は何か？
-   - 目的が異なるとき、この用語の意味（属性、振る舞い、ルール）はどう変わるか？
+2. **Find semantic divergence points:** For each term, ask:
+   - Which actors use this term?
+   - What is each actor's purpose?
+   - When purposes differ, how do the term's meaning (attributes, behavior, rules) change?
 
-3. **言語ゲーム分析表の作成:**
+3. **Create a language game analysis table:**
 
 ```markdown
 | 用語 | アクター | 目的 | この文脈での意味 | 主要な属性/ルール |
@@ -99,19 +99,19 @@ allowed-tools:
 | 商品 | 物流担当 | 配送 | 配送対象（重量、サイズ、配送区分） | 梱包ルール、配送料計算 |
 ```
 
-4. **分岐の確認:** 意味が明確に異なる場合 → 異なるコンテキストの候補
+4. **Confirm divergence:** If meanings clearly differ → candidate for different contexts
 
-> **重要:** 分析の詳細な手法については `references/language-game-guide.md` を参照すること。
+> **Important:** Refer to `references/language-game-guide.md` for detailed analysis methods.
 
-### Phase 4: コンテキスト境界の定義
+### Phase 4: Context Boundary Definition
 
-**目標:** 各境界付けられたコンテキストを正式に定義する。
+**Goal:** Formally define each bounded context.
 
-1. Phase 3 の分析結果をもとに、コンテキスト候補をグループ化する:
-   - 同じアクター × 同じ目的 × 同じルール群 → 1つのコンテキスト
-   - 無理に分割しすぎない（凝集度を重視）
+1. Group context candidates based on Phase 3 results:
+   - Same actor × same purpose × same rule set → one context
+   - Avoid over-splitting (prioritize cohesion)
 
-2. 各コンテキストを定義する:
+2. Define each context:
 
 ```markdown
 ## コンテキスト: [名前]
@@ -129,28 +129,28 @@ allowed-tools:
   - [モデル1]: [説明]
 ```
 
-3. テンプレートは `references/context-analysis-template.md` を使用する。
+3. Use the template from `references/context-analysis-template.md`.
 
-### Phase 5: コンテキスト間の関係定義（コンテキストマップ）
+### Phase 5: Context Relationship Definition (Context Map)
 
-**目標:** コンテキスト間の関係性と統合パターンを定義する。
+**Goal:** Define relationships and integration patterns between contexts.
 
-1. コンテキスト間の関係を特定する:
-   - どのコンテキストがどのコンテキストのデータを必要とするか
-   - データの流れの方向性
+1. Identify inter-context relationships:
+   - Which context needs data from which other context
+   - Direction of data flow
 
-2. 統合パターンを選択する:
+2. Select integration patterns:
 
-| パターン | 使用場面 |
-|----------|----------|
-| Shared Kernel | 2つのコンテキストが密結合で共有部分が小さい場合 |
-| Customer-Supplier | 上流が下流のニーズに応える関係 |
-| Conformist | 下流が上流のモデルにそのまま従う |
-| Anti-Corruption Layer | 外部/レガシーシステムとの統合 |
-| Published Language | 標準化されたインターフェースで統合 |
-| Separate Ways | 統合の必要がない |
+| Pattern | Use case |
+|---------|----------|
+| Shared Kernel | Two contexts are tightly coupled with a small shared part |
+| Customer-Supplier | Upstream serves downstream's needs |
+| Conformist | Downstream conforms to upstream's model as-is |
+| Anti-Corruption Layer | Integration with external/legacy systems |
+| Published Language | Integration via standardized interfaces |
+| Separate Ways | No integration needed |
 
-3. コンテキストマップを Mermaid 形式で出力する:
+3. Output the context map in Mermaid format:
 
 ```mermaid
 graph LR
@@ -161,36 +161,36 @@ graph LR
 
 ---
 
-## 出力形式
+## Output Format
 
-分析結果は以下のパスに保存する:
+Save analysis results at the following path:
 
 ```text
 <project>/docs/ddd/
-├── context-map.md              # コンテキストマップ（全体像）
+├── context-map.md              # Context map (overview)
 ├── contexts/
-│   ├── <context-name-1>.md     # 各コンテキストの詳細（テンプレート使用）
+│   ├── <context-name-1>.md     # Each context's details (using template)
 │   ├── <context-name-2>.md
 │   └── ...
-└── language-games.md           # 言語ゲーム分析表（Phase 3 の成果物）
+└── language-games.md           # Language game analysis table (Phase 3 deliverable)
 ```
 
-- `context-map.md`: Mermaid 図 + コンテキスト間関係の説明
-- `contexts/<name>.md`: `references/context-analysis-template.md` に基づく各コンテキストの定義
-- `language-games.md`: 用語の意味の分岐分析
+- `context-map.md`: Mermaid diagram + description of inter-context relationships
+- `contexts/<name>.md`: Each context definition based on `references/context-analysis-template.md`
+- `language-games.md`: Term semantic divergence analysis
 
 ---
 
-## 重要な注意事項
+## Important Notes
 
-1. **完璧を目指さない:** 境界付けられたコンテキストは反復的に洗練されるもの。最初の分析で完璧な境界を引く必要はない。
+1. **Don't aim for perfection:** Bounded contexts are refined iteratively. The first analysis doesn't need perfect boundaries.
 
-2. **アクターの目的から始める:** 技術的な関心（データベース、API）からではなく、ビジネス上の目的から境界を導出する。
+2. **Start from actor purposes:** Derive boundaries from business purposes, not technical concerns (databases, APIs).
 
-3. **用語の一致は偶然かもしれない:** 同じ名前が使われているからといって同じ概念とは限らない。必ず「誰が・何のために使うか」を確認する。
+3. **Matching terms may be coincidental:** The same name doesn't necessarily mean the same concept. Always verify "who uses it and for what purpose."
 
-4. **用語の不一致も偶然かもしれない:** 異なる名前が使われていても、同じコンテキスト内の同じ概念かもしれない。
+4. **Mismatching terms may also be coincidental:** Different names may still refer to the same concept within a context.
 
-5. **既存コードを尊重する:** 既にコードベースがある場合、理想的な境界と現実のコード構造のギャップを明示し、段階的な移行戦略を提案する。
+5. **Respect existing code:** If a codebase exists, explicitly show the gap between ideal boundaries and actual code structure, and suggest an incremental migration strategy.
 
-6. **ユーザーとの対話を重視する:** ドメインエキスパートはユーザー自身。分析中に不明点があれば必ず確認する。
+6. **Prioritize dialogue with users:** The domain expert is the user. Always confirm uncertainties during analysis.

--- a/.claude/skills/bounded-context/references/context-analysis-template.md
+++ b/.claude/skills/bounded-context/references/context-analysis-template.md
@@ -1,7 +1,7 @@
-# コンテキスト分析テンプレート
+# Context Analysis Template
 
-> このテンプレートを使って各境界付けられたコンテキストの分析結果を記録する。
-> `<project>/docs/ddd/contexts/<context-name>.md` として保存すること。
+> Use this template to record the analysis results for each bounded context.
+> Save as `<project>/docs/ddd/contexts/<context-name>.md`.
 
 ---
 
@@ -62,8 +62,8 @@
 
 ### このコンテキスト特有の用語の使われ方
 
-> ここに、このコンテキストで用語がどのような「ゲーム」の中で使われるかを記述する。
-> 他のコンテキストと同じ用語でも意味が異なる場合は、その違いを明記する。
+> Describe how terms are used in the specific "game" of this context.
+> If the same term has different meanings in other contexts, document the differences.
 
 ```
 用語「___」について:
@@ -74,5 +74,5 @@
 
 ### 境界の根拠
 
-> なぜこの範囲がひとつのコンテキストとして切り出されたかの根拠を記述する。
-> アクターの目的、ルールの一貫性、用語の意味の統一性の観点から説明する。
+> Document why this scope was carved out as a single context.
+> Explain from the perspectives of actor purposes, rule consistency, and term semantic coherence.

--- a/.claude/skills/bounded-context/references/language-game-guide.md
+++ b/.claude/skills/bounded-context/references/language-game-guide.md
@@ -1,157 +1,157 @@
-# 言語ゲーム概念と分析手法ガイド
+# Language Game Concepts and Analysis Method Guide
 
-## ヴィトゲンシュタインの言語ゲーム
+## Wittgenstein's Language Games
 
-### 核心概念
+### Core Concept
 
-ルートヴィヒ・ヴィトゲンシュタインは後期の主著『哲学探究』で、言語の意味についての見方を根本的に転換した。
+In his later work *Philosophical Investigations*, Ludwig Wittgenstein fundamentally shifted the view on the meaning of language.
 
-**前期（『論理哲学論考』）:** 言語は世界を「写像」する → 語には固定された意味がある
-**後期（『哲学探究』）:** 語の意味とは言語におけるその**使用**である（第43節）
+**Early period (*Tractatus Logico-Philosophicus*):** Language "pictures" the world → words have fixed meanings
+**Later period (*Philosophical Investigations*):** The meaning of a word is its **use** in the language (§43)
 
 > "Die Bedeutung eines Wortes ist sein Gebrauch in der Sprache."
-> （語の意味とは、言語におけるその使用である）
+> (The meaning of a word is its use in the language.)
 
-### 言語ゲームとは
+### What Are Language Games?
 
-- 言葉の使用は「ゲーム」のようなもの：参加者、ルール、目的がある
-- 同じ言葉でも、異なるゲーム（文脈）では異なるルールで使われる
-- ゲームのルールは事前に定義されるのではなく、実践の中で形成される
-- 「家族的類似性」：すべてのゲームに共通する本質はない。類似点のネットワークがあるだけ
+- The use of words is like a "game": there are participants, rules, and purposes
+- The same word operates under different rules in different games (contexts)
+- Game rules are not defined in advance but formed through practice
+- "Family resemblance": there is no common essence to all games — only a network of similarities
 
-### 重要な示唆
+### Key Implications
 
-1. **意味は辞書にはない:** 辞書的定義ではなく、実際の使用場面を観察せよ
-2. **文脈が意味を決定する:** 同じ語でも異なる「ゲーム」では異なる意味を持つ
-3. **ルールは実践から生まれる:** トップダウンの定義より、ボトムアップの観察が重要
+1. **Meaning is not in the dictionary:** Observe actual usage, not dictionary definitions
+2. **Context determines meaning:** The same word has different meanings in different "games"
+3. **Rules emerge from practice:** Bottom-up observation matters more than top-down definitions
 
 ---
 
-## ソフトウェア設計への応用
+## Application to Software Design
 
-### なぜ言語ゲームがDDDに有効か
+### Why Language Games Are Effective for DDD
 
-DDDの中心概念「ユビキタス言語」は、コンテキスト内で一貫した用語を使うことを求める。
-しかし、**どこでコンテキストを区切るか**の判断基準が曖昧になりがちである。
+DDD's core concept "Ubiquitous Language" requires consistent terminology within a context.
+However, the criteria for **where to draw context boundaries** tend to be ambiguous.
 
-言語ゲームの観点を導入すると:
+Introducing the language game perspective:
 
-- **コンテキスト境界** = 異なる言語ゲームが行われている境界
-- **ユビキタス言語** = 特定の言語ゲーム内でのルール体系
-- **コンテキストの発見** = 「同じ言葉が異なるゲームで使われている」場面を見つけること
+- **Context boundary** = boundary where different language games are played
+- **Ubiquitous language** = the rule system within a specific language game
+- **Context discovery** = finding situations where "the same word is used in different games"
 
-### MinoDriven アプローチ: 目的駆動の言語ゲーム分析
+### MinoDriven Approach: Purpose-Driven Language Game Analysis
 
-@MinoDriven（仙塲大也）氏は、アクターの**目的**を言語ゲームの文脈として捉える:
+@MinoDriven (Daiya Seba) treats the actor's **purpose** as the context of the language game:
 
 ```text
-アクター × 目的 → 言語ゲーム（文脈） → ルール群 → コンテキスト
+Actor × Purpose → Language Game (Context) → Rule Set → Bounded Context
 ```
 
-これにより「なぜそこで境界を引くのか」が明確になる:
-**目的が異なれば、同じ言葉に異なるルールが適用されるから。**
+This clarifies "why draw the boundary there":
+**Because different purposes cause different rules to apply to the same words.**
 
 ---
 
-## 具体例: ECサイトにおける「商品」の言語ゲーム
+## Concrete Example: "商品" (Product) in an EC Site
 
-### ゲーム1: 購買ゲーム
+### Game 1: Purchasing Game (購買ゲーム)
 
-- **参加者:** 購入者
-- **目的:** 欲しい商品を見つけて購入する
-- **「商品」の意味:** 購入の対象
-- **関連属性:** 商品名、価格（税込表示価格）、レビュー評価、在庫有無、カテゴリ
-- **ルール:**
+- **Participant:** 購入者 (Buyer)
+- **Purpose:** Find and purchase desired products
+- **Meaning of "商品":** Object of purchase
+- **Related attributes:** 商品名、価格（税込表示価格）、レビュー評価、在庫有無、カテゴリ
+- **Rules:**
   - 在庫がなければ購入できない
   - 価格は税込で表示する
   - レビューは購入者のみ投稿できる
 
-### ゲーム2: 販売管理ゲーム
+### Game 2: Sales Management Game (販売管理ゲーム)
 
-- **参加者:** 出品者/販売者
-- **目的:** 商品を販売して利益を得る
-- **「商品」の意味:** 販売して利益を生む資産
-- **関連属性:** 商品名、原価、販売価格、利益率、在庫数、仕入先
-- **ルール:**
+- **Participant:** 出品者/販売者 (Seller)
+- **Purpose:** Sell products for profit
+- **Meaning of "商品":** Asset that generates profit through sales
+- **Related attributes:** 商品名、原価、販売価格、利益率、在庫数、仕入先
+- **Rules:**
   - 利益率が閾値以下なら値上げを検討する
   - 在庫が閾値以下なら自動発注する
   - 販売実績に基づいて価格を調整する
 
-### ゲーム3: 物流ゲーム
+### Game 3: Logistics Game (物流ゲーム)
 
-- **参加者:** 物流担当/倉庫管理者
-- **目的:** 商品を正確かつ効率的に配送する
-- **「商品」の意味:** 配送・保管の対象物
-- **関連属性:** 重量、サイズ、配送区分、保管条件、SKU
-- **ルール:**
+- **Participant:** 物流担当/倉庫管理者 (Logistics/Warehouse manager)
+- **Purpose:** Deliver products accurately and efficiently
+- **Meaning of "商品":** Object of delivery and storage
+- **Related attributes:** 重量、サイズ、配送区分、保管条件、SKU
+- **Rules:**
   - 重量とサイズで配送料が決まる
   - 温度管理が必要な商品は専用ラインで配送
   - 同一倉庫の商品はまとめて配送可能
 
-### 分析結果
+### Analysis Result
 
-「商品」という同じ言葉が3つの異なるゲームで使われている。各ゲームで:
-- 持つべき属性が異なる
-- 適用されるルールが異なる
-- 関心事が異なる
+The same word "商品" is used in three different games. In each game:
+- The required attributes differ
+- The applicable rules differ
+- The concerns differ
 
-→ これは3つの異なる境界付けられたコンテキストの候補である。
-
----
-
-## 分析の進め方
-
-### Step 1: 用語を集める
-
-- ドメインエキスパートとの会話、既存ドキュメント、コードから主要な名詞・動詞を収集する
-- 特に「全員が当然知っている」と思っている用語に注意する（暗黙の多義性が潜む）
-
-### Step 2: 使用場面を観察する
-
-各用語について:
-- **誰が**使っているか（アクター）
-- **何のために**使っているか（目的）
-- **どんなルール**の下で使っているか
-
-辞書的な定義を聞くのではなく、**実際の使用場面**を聞く。
-
-> 良い質問: 「『商品』という言葉を使うとき、どんな作業をしていますか？」
-> 悪い質問: 「『商品』の定義は何ですか？」
-
-### Step 3: 意味の分岐を発見する
-
-同じ用語が異なるアクター/目的で使われるとき:
-- 属性が異なるか？
-- ルールが異なるか？
-- ライフサイクルが異なるか？
-
-1つでも「はい」なら、コンテキスト境界の候補。
-
-### Step 4: 境界を検証する
-
-発見した境界候補について:
-- この境界で分けると、各コンテキスト内の用語は一貫するか？
-- コンテキスト間のやり取りは明確に定義できるか？
-- チーム構成と整合するか（コンウェイの法則）？
+→ These are candidates for three different bounded contexts.
 
 ---
 
-## 他の手法との関係
+## How to Conduct Analysis
 
-### イベントストーミング
+### Step 1: Collect Terms
 
-- イベントストーミングは**出来事（イベント）**を起点にドメインを探索する
-- 言語ゲーム分析は**用語の使われ方**を起点にする
-- 相補的に使える: イベントストーミングで発見したイベントに含まれる用語を、言語ゲーム分析で深掘りする
+- Gather major nouns and verbs from conversations with domain experts, existing documents, and code
+- Pay special attention to terms "everyone assumes they know" (implicit polysemy lurks there)
 
-### ドメインストーリーテリング
+### Step 2: Observe Usage
 
-- ドメインストーリーテリングは**アクターの行動の流れ**を図示する
-- 言語ゲーム分析はその中で使われる**用語の意味の変化**に注目する
-- ドメインストーリーの中で「同じ名詞なのに文脈で違うことを指している」箇所が、コンテキスト境界の手がかりになる
+For each term:
+- **Who** uses it (Actor)
+- **For what purpose** (Purpose)
+- **Under what rules**
 
-### コンテキストマッピング
+Don't ask for dictionary definitions — ask about **actual usage scenarios**.
 
-- コンテキストマッピングは**コンテキスト間の関係**を定義する
-- 言語ゲーム分析は**コンテキスト自体の発見**を支援する
-- 言語ゲーム分析 → コンテキスト発見 → コンテキストマッピング の順で使う
+> Good question: 「『商品』という言葉を使うとき、どんな作業をしていますか？」
+> Bad question: 「『商品』の定義は何ですか？」
+
+### Step 3: Discover Semantic Divergence
+
+When the same term is used by different actors/purposes:
+- Do the attributes differ?
+- Do the rules differ?
+- Does the lifecycle differ?
+
+If any answer is "yes," it's a candidate for a context boundary.
+
+### Step 4: Validate Boundaries
+
+For discovered boundary candidates:
+- Does splitting at this boundary make terminology consistent within each context?
+- Can inter-context interactions be clearly defined?
+- Does it align with team structure (Conway's Law)?
+
+---
+
+## Relationship with Other Methods
+
+### Event Storming
+
+- Event Storming explores the domain starting from **events**
+- Language game analysis starts from **how terms are used**
+- Complementary: drill down into terms found in events discovered via Event Storming
+
+### Domain Storytelling
+
+- Domain Storytelling illustrates **the flow of actor actions**
+- Language game analysis focuses on **changes in term meanings** within those flows
+- Points where "the same noun refers to different things depending on context" are clues for context boundaries
+
+### Context Mapping
+
+- Context Mapping defines **relationships between contexts**
+- Language game analysis supports **discovering contexts themselves**
+- Use in sequence: Language game analysis → Context discovery → Context Mapping


### PR DESCRIPTION
## Summary

- bounded-context スキルの指示文（Claudeへのプロンプト）を日本語から英語に変換
- 日本語はClaudeのトークナイザーで英語の約2〜3倍のトークンを消費するため、スキル呼び出し時のコンテキスト効率を改善
- ユーザー向けの `description`（frontmatter）、出力テンプレート、ドメイン例示は日本語を維持

## Changed files

| File | Change |
|------|--------|
| `SKILL.md` | Instructions/headings → English, output templates/domain terms → Japanese |
| `references/context-analysis-template.md` | Instructions → English, template headers → Japanese |
| `references/language-game-guide.md` | Explanations → English, domain examples → Japanese |

## Test plan

- [ ] `bounded-context` スキルが正常に呼び出せることを確認
- [ ] 出力テンプレートが日本語で生成されることを確認