### PR TITLE
feat: enable word wrap for markdown files in nvim

### DIFF
--- a/.config/nvim/ftplugin/markdown.lua
+++ b/.config/nvim/ftplugin/markdown.lua
@@ -1,0 +1,14 @@
+-- Markdown固有の設定
+
+-- はみ出した行を折り返して表示する
+vim.opt_local.wrap = true
+
+-- 単語の途中で折り返さない
+vim.opt_local.linebreak = true
+
+-- 折り返し行のインデントを維持する
+vim.opt_local.breakindent = true
+
+-- 表示行単位で移動する（折り返し行でも自然に上下移動できる）
+vim.keymap.set("n", "j", "gj", { buffer = true })
+vim.keymap.set("n", "k", "gk", { buffer = true })


### PR DESCRIPTION
## Summary
- markdownファイルでの行の折り返し表示を有効化（`wrap`, `linebreak`, `breakindent`）
- `j`/`k` を `gj`/`gk` にマッピングし、折り返し行での自然な上下移動を実現
- markdown filetype のみに適用され、他のファイルタイプには影響なし

Closes #43

## Test plan
- [ ] markdownファイルを開き、長い行が自動的に折り返されることを確認
- [ ] 折り返し行で `j`/`k` を押して表示行単位で移動できることを確認
- [ ] 単語の途中で折り返されないことを確認（`linebreak`）
- [ ] 他のファイルタイプ（.lua, .ts等）では折り返しが無効のままであることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Configuration**
  * Added word-wrapping support for Markdown files that preserves word boundaries
  * Wrapped lines now maintain original indentation
  * Navigation optimized to move naturally across wrapped content

<!-- end of auto-generated comment: release notes by coderabbit.ai -->