### PR TITLE
fix: ~/.configシンボリックリンク解消とmkOutOfStoreSymlink復元

### DIFF
--- a/.bin/setup.sh
+++ b/.bin/setup.sh
@@ -29,7 +29,14 @@ link_to_homedir() {
       # .zshrc は home-manager (Nix) が管理するためスキップ
       [[ $(basename "$f") == ".zshrc" ]] && continue
       # .config は home-manager が xdg.configFile で管理するためスキップ
-      [[ $(basename "$f") == ".config" ]] && continue
+      # レガシーなシンボリックリンク ~/.config → dotfiles/.config が残っていれば削除
+      if [[ $(basename "$f") == ".config" ]]; then
+        if [[ -L "$HOME/.config" ]]; then
+          command echo "removing legacy symlink: ~/.config -> $(readlink "$HOME/.config")"
+          command rm -f "$HOME/.config"
+        fi
+        continue
+      fi
       if [[ -L "$HOME/$(basename "$f")" ]];then
         command rm -f "$HOME/$(basename "$f")"
       fi

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -28,25 +28,16 @@ in
   };
 
   # ------------------------------------------------------------------
-  # dotfiles — flake 相対パスで Nix store にコピーしてリンク
-  # 設定変更時は make switch で反映
+  # dotfiles — mkOutOfStoreSymlink で既存設定をそのままリンク
+  # rebuild 不要で設定変更が即反映される
   # ------------------------------------------------------------------
   xdg.configFile = {
-    "nvim" = {
-      source = ../.config/nvim;
-      recursive = true;
-    };
-    "wezterm" = {
-      source = ../.config/wezterm;
-      recursive = true;
-    };
-    "zsh" = {
-      source = ../.config/zsh;
-      recursive = true;
-    };
-    "starship.toml".source = ../.config/starship.toml;
-    "git/ignore".source = ../.config/git/ignore;
-    "gh/config.yml".source = ../.config/gh/config.yml;
+    "nvim".source = config.lib.file.mkOutOfStoreSymlink "${dotfilesDir}/.config/nvim";
+    "wezterm".source = config.lib.file.mkOutOfStoreSymlink "${dotfilesDir}/.config/wezterm";
+    "zsh".source = config.lib.file.mkOutOfStoreSymlink "${dotfilesDir}/.config/zsh";
+    "starship.toml".source = config.lib.file.mkOutOfStoreSymlink "${dotfilesDir}/.config/starship.toml";
+    "git/ignore".source = config.lib.file.mkOutOfStoreSymlink "${dotfilesDir}/.config/git/ignore";
+    "gh/config.yml".source = config.lib.file.mkOutOfStoreSymlink "${dotfilesDir}/.config/gh/config.yml";
   };
 
   # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `~/.config` → `~/dotfiles/.config` のレガシーなシンボリックリンクが root cause で、home-manager のデプロイ先とリポジトリが重複し typechange が常に発生していた
- setup.sh でレガシーシンボリックリンクを検出・削除する処理を追加
- home.nix を `mkOutOfStoreSymlink` 方式に戻し、設定変更が `make switch` 不要で即反映されるようにする

## Why
PR #58 で flake 相対パス方式に変更したのは、`mkOutOfStoreSymlink` がリポジトリ内のファイルをシンボリックリンクで上書きする問題を回避するためだった。しかし真の原因は `~/.config` 自体が `~/dotfiles/.config` へのシンボリックリンクだったことで、このリンクを解消すれば `mkOutOfStoreSymlink` でも問題は起きない。

## Test plan
- [ ] `make setup` で `~/.config` シンボリックリンクが削除されることを確認
- [ ] `make switch` 後に `~/.config/nvim` が `~/dotfiles/.config/nvim` を指すことを確認
- [ ] `git status` で typechange が表示されないことを確認
- [ ] CI (lint + nix build) が通ることを確認