### PR TITLE
feat: Codex CLI を Nix で導入し設定を dotfiles 管理

### DIFF
--- a/.config/codex/config.toml
+++ b/.config/codex/config.toml
@@ -1,0 +1,14 @@
+model = "gpt-5-codex"
+approval_policy = "on-request"
+sandbox_mode = "workspace-write"
+
+[profiles.chatgpt]
+preferred_auth_method = "chatgpt"
+
+[profiles.apikey]
+preferred_auth_method = "apikey"
+
+# --- MCP servers ---
+# [mcp_servers.context7]
+# command = "npx"
+# args = ["-y", "@upstash/context7-mcp"]

--- a/.config/codex/config.toml
+++ b/.config/codex/config.toml
@@ -1,4 +1,4 @@
-model = "gpt-5-codex"
+model = "gpt-5.4"
 approval_policy = "on-request"
 sandbox_mode = "workspace-write"
 

--- a/.config/zsh/secrets.zsh.example
+++ b/.config/zsh/secrets.zsh.example
@@ -1,0 +1,6 @@
+# Template for ~/.config/zsh/secrets.zsh
+# Auto-copied by home-manager activation if the real file doesn't exist.
+# Edit the real file (~/.config/zsh/secrets.zsh) — never commit it.
+
+# export OPENAI_API_KEY="sk-..."
+# export ANTHROPIC_API_KEY="sk-ant-..."

--- a/.gitignore
+++ b/.gitignore
@@ -87,8 +87,12 @@
 # zsh
 !/.config/zsh/
 !/.config/zsh/**
+# codex
+!/.config/codex/
+!/.config/codex/config.toml
 # Exclude from whitelisted dirs above
 *.hm-backup
+/.config/zsh/secrets.zsh
 /.config/gh/hosts.yml
 /.config/git/config
 /.config/nvim/lazy-lock.json
@@ -105,6 +109,10 @@
 /.claude/hooks/__pycache__/
 !/.claude/skills/
 !/.claude/skills/**
+
+# agents (codex skills など複数AIツール共通の ~/.agents/skills/)
+!/.agents/
+!/.agents/**
 # Exclude local settings (machine-specific)
 /.claude/settings.local.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -111,8 +111,11 @@
 !/.claude/skills/**
 
 # agents (codex skills など複数AIツール共通の ~/.agents/skills/)
+# skills 配下のみホワイトリスト化 — 他のランタイム/状態ファイルが混入しないよう制限
 !/.agents/
-!/.agents/**
+/.agents/*
+!/.agents/skills/
+!/.agents/skills/**
 # Exclude local settings (machine-specific)
 /.claude/settings.local.json
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ dotfiles/
 │   ├── nvim/              # Neovim (Lua + lazy.nvim)
 │   ├── wezterm/           # WezTerm ターミナル
 │   ├── starship.toml      # Starship プロンプト
-│   ├── codex/             # OpenAI Codex CLI 設定 (~/.codex/ にsymlink)
+│   ├── codex/             # OpenAI Codex CLI 設定テンプレ (初回 switch で ~/.codex/ にコピー)
 │   └── zsh/               # Zsh 補完・fzf・IDE関数・secrets テンプレ
 ├── .agents/skills/        # AI agent skills (Codex 等で共通利用)
 ├── .claude/               # Claude Code 設定
@@ -77,8 +77,9 @@ Apple Silicon (aarch64) と Intel (x86_64) の両方に対応しています。
 
 ## dotfiles の設定変更
 
-nvim / wezterm / starship / zsh / codex の設定ファイルを編集した後は `make switch` で反映してください。
-パッケージの追加・削除や `programs.*` の変更も同様です。
+nvim / wezterm / starship / zsh の設定ファイルは `mkOutOfStoreSymlink` 経由で `~/.config/` に symlink されているため、編集すれば即反映されます。`make switch` が必要なのは Nix 宣言の変更 (パッケージ追加・削除や `programs.*` の変更など) のみです。
+
+Codex の `config.toml` は dotfiles 側のファイルが「初期テンプレ」として `~/.codex/config.toml` にコピーされます (Codex 自身が `[projects.*]` 等の実行時状態を書き込むため symlink にできない)。テンプレを更新して反映したい場合は `rm ~/.codex/config.toml && make switch` してください。
 
 ## API キー / シークレット
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ dotfiles/
 │   ├── nvim/              # Neovim (Lua + lazy.nvim)
 │   ├── wezterm/           # WezTerm ターミナル
 │   ├── starship.toml      # Starship プロンプト
-│   └── zsh/               # Zsh 補完・fzf・IDE関数
+│   ├── codex/             # OpenAI Codex CLI 設定 (~/.codex/ にsymlink)
+│   └── zsh/               # Zsh 補完・fzf・IDE関数・secrets テンプレ
+├── .agents/skills/        # AI agent skills (Codex 等で共通利用)
 ├── .claude/               # Claude Code 設定
 ├── Makefile               # install / setup / switch / lint
 └── .github/workflows/     # CI (lint + build check)
@@ -42,7 +44,7 @@ dotfiles/
 
 | カテゴリ | パッケージ |
 |---------|-----------|
-| CLI ツール | starship, fzf, fd, bat, neovim, lazygit, ripgrep, jq, direnv |
+| CLI ツール | starship, fzf, fd, bat, neovim, lazygit, ripgrep, jq, direnv, codex |
 | フォント | JetBrainsMono Nerd Font |
 | Lint (devShell) | shellcheck, stylua, taplo, ruff, jq |
 | GUI アプリ | WezTerm（手動インストール） |
@@ -75,5 +77,12 @@ Apple Silicon (aarch64) と Intel (x86_64) の両方に対応しています。
 
 ## dotfiles の設定変更
 
-nvim / wezterm / starship / zsh の設定ファイルを編集した後は `make switch` で反映してください。
+nvim / wezterm / starship / zsh / codex の設定ファイルを編集した後は `make switch` で反映してください。
 パッケージの追加・削除や `programs.*` の変更も同様です。
+
+## API キー / シークレット
+
+`~/.config/zsh/secrets.zsh` に環境変数を export する形で管理します。
+初回 `make switch` 時に `.config/zsh/secrets.zsh.example` から自動コピーされます (既存ファイルは上書きしません)。
+このファイルは git 管理対象外です。Codex の API キー認証を使う場合は `OPENAI_API_KEY` をここで設定してください。
+ChatGPT ログイン認証を使う場合は `codex login` を1度実行すれば `~/.codex/auth.json` が自動生成されます。

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -43,11 +43,13 @@ in
       # 既存ファイルでも権限は常に 600 に矯正
       run chmod 600 "$HOME/.config/zsh/secrets.zsh"
 
-      run mkdir -p "$HOME/.codex"
+      # codex は ~/.codex/auth.json に OAuth/APIキーを保存するため restrictive に作成
+      run install -d -m 700 "$HOME/.codex"
       if [ ! -f "$HOME/.codex/config.toml" ]; then
-        run cp "${dotfilesDir}/.config/codex/config.toml" \
-               "$HOME/.codex/config.toml"
+        run install -m 600 "${dotfilesDir}/.config/codex/config.toml" \
+                           "$HOME/.codex/config.toml"
       fi
+      run chmod 600 "$HOME/.codex/config.toml"
     '';
   };
 

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -24,7 +24,25 @@ in
       ripgrep
       jq
       nerd-fonts.jetbrains-mono
+      codex
     ];
+
+    # Codex は ~/.codex/ 固定 (XDG非準拠) なので home.file で配置
+    file.".codex/config.toml".source =
+      config.lib.file.mkOutOfStoreSymlink "${dotfilesDir}/.config/codex/config.toml";
+
+    # Skills は ~/.agents/skills/ (複数AIツール共通の標準パス)
+    file.".agents/skills".source =
+      config.lib.file.mkOutOfStoreSymlink "${dotfilesDir}/.agents/skills";
+
+    # secrets.zsh が無ければテンプレから初回のみコピー (既存は絶対上書きしない)
+    activation.copySecretsTemplate = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      if [ ! -f "$HOME/.config/zsh/secrets.zsh" ]; then
+        run cp ${dotfilesDir}/.config/zsh/secrets.zsh.example \
+               $HOME/.config/zsh/secrets.zsh
+        run chmod 600 $HOME/.config/zsh/secrets.zsh
+      fi
+    '';
   };
 
   # ------------------------------------------------------------------
@@ -90,6 +108,9 @@ in
     initContent = ''
       # ~/.local/bin (claude CLI etc.)
       [[ -f "$HOME/.local/bin/env" ]] && . "$HOME/.local/bin/env"
+
+      # API keys / secrets (gitignored, copied from template on first switch)
+      [[ -f "$HOME/.config/zsh/secrets.zsh" ]] && source "$HOME/.config/zsh/secrets.zsh"
 
       # Package manager completions (npm/yarn/pnpm)
       [[ -f "$HOME/.config/zsh/completions.zsh" ]] && source "$HOME/.config/zsh/completions.zsh"

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -27,20 +27,26 @@ in
       codex
     ];
 
-    # Codex は ~/.codex/ 固定 (XDG非準拠) なので home.file で配置
-    file.".codex/config.toml".source =
-      config.lib.file.mkOutOfStoreSymlink "${dotfilesDir}/.config/codex/config.toml";
-
     # Skills は ~/.agents/skills/ (複数AIツール共通の標準パス)
     file.".agents/skills".source =
       config.lib.file.mkOutOfStoreSymlink "${dotfilesDir}/.agents/skills";
 
-    # secrets.zsh が無ければテンプレから初回のみコピー (既存は絶対上書きしない)
-    activation.copySecretsTemplate = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    # secrets.zsh / codex/config.toml はテンプレから初回のみコピー (既存は絶対上書きしない)
+    # codex は config.toml に [projects.*] 等の実行時状態を追記するため symlink にできない
+    activation.copyTemplates = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      run mkdir -p "$HOME/.config/zsh"
       if [ ! -f "$HOME/.config/zsh/secrets.zsh" ]; then
-        run cp ${dotfilesDir}/.config/zsh/secrets.zsh.example \
-               $HOME/.config/zsh/secrets.zsh
-        run chmod 600 $HOME/.config/zsh/secrets.zsh
+        # install -m 600 で atomic に正しい権限で作成 (cp+chmod の race を回避)
+        run install -m 600 "${dotfilesDir}/.config/zsh/secrets.zsh.example" \
+                           "$HOME/.config/zsh/secrets.zsh"
+      fi
+      # 既存ファイルでも権限は常に 600 に矯正
+      run chmod 600 "$HOME/.config/zsh/secrets.zsh"
+
+      run mkdir -p "$HOME/.codex"
+      if [ ! -f "$HOME/.codex/config.toml" ]; then
+        run cp "${dotfilesDir}/.config/codex/config.toml" \
+               "$HOME/.codex/config.toml"
       fi
     '';
   };


### PR DESCRIPTION
## Summary
- `pkgs.codex` を `home.packages` に追加して OpenAI Codex CLI を Nix 管理化
- `~/.codex/config.toml` を dotfiles のテンプレから初回のみコピー (Codex が `[projects.*]` 等のランタイム状態を追記するため symlink 不可)
- `~/.agents/skills/` を `mkOutOfStoreSymlink` で dotfiles 管理 (AI agent skills 用ディレクトリ、複数ツール共通の標準パス)
- `~/.config/zsh/secrets.zsh` の仕組みを追加 — テンプレ `.example` から `home.activation` で初回のみ `install -m 600` で生成、git 管理外、zsh 起動時に source
- `~/.codex` ディレクトリは 700、`config.toml` は 600 で作成 (`auth.json` に認証情報が保存されるため)

## 認証の使い分け
- **ChatGPT ログイン派**: `codex login` を1回実行 → `~/.codex/auth.json` 自動生成 (Nix 管理外)
- **API キー派**: `~/.config/zsh/secrets.zsh` を編集して `OPENAI_API_KEY` を有効化 → `codex --profile apikey`

## Test plan
- [x] `nix flake check` 通過
- [x] `make switch` 成功、`codex --version` 確認 (0.45.0)
- [x] `~/.codex/config.toml` が dotfiles テンプレから生成されている
- [x] `~/.agents/skills` が dotfiles に symlink されている
- [x] `~/.config/zsh/secrets.zsh` がテンプレから自動コピーされ mode 600
- [ ] `codex login` で ChatGPT 認証フロー確認
- [ ] `OPENAI_API_KEY` 設定後 `codex --profile apikey` で API キー認証確認