### PR TITLE
feat: Node.js 22 (LTS) を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ dotfiles/
 | カテゴリ | パッケージ |
 |---------|-----------|
 | CLI ツール | starship, fzf, fd, bat, neovim, lazygit, ripgrep, jq, direnv, codex |
+| ランタイム | Node.js 22 (LTS) |
 | フォント | JetBrainsMono Nerd Font |
 | Lint (devShell) | shellcheck, stylua, taplo, ruff, jq |
 | GUI アプリ | WezTerm（手動インストール） |

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -25,6 +25,7 @@ in
       jq
       nerd-fonts.jetbrains-mono
       codex
+      nodejs_22
     ];
 
     # Skills は ~/.agents/skills/ (複数AIツール共通の標準パス)


### PR DESCRIPTION
## Summary
- `pkgs.nodejs_22` を `home.packages` に追加
- LTS (22系) を採用。最新の 24 ではなくグローバル CLI 用途で安定寄りに

## Test plan
- [x] `nix flake check` 通過
- [ ] `make switch` 実行後 `node --version` で v22 系を確認
- [ ] `npm --version` が同梱で利用できることを確認