### PR TITLE
feat: nvim にマージコンフリクト対応プラグインを追加

### DIFF
--- a/.config/nvim/lua/plugins/git.lua
+++ b/.config/nvim/lua/plugins/git.lua
@@ -119,4 +119,39 @@ return {
       { "<leader>gf", "<cmd>LazyGitCurrentFile<CR>", desc = "現在のファイルのLazyGit" },
     },
   },
+
+  -- git-conflict.nvim: コンフリクトマーカーのハイライトと選択操作
+  {
+    "akinsho/git-conflict.nvim",
+    version = "*",
+    event = "BufReadPre",
+    opts = {
+      default_mappings = true, -- co/ct/cb/c0 と ]x/[x を有効化
+      default_commands = true,
+      disable_diagnostics = true,
+      list_opener = "copen",
+      highlights = {
+        incoming = "DiffAdd",
+        current = "DiffText",
+      },
+    },
+  },
+
+  -- diffview.nvim: 3-way マージビューと差分ブラウザ
+  {
+    "sindrets/diffview.nvim",
+    dependencies = { "nvim-lua/plenary.nvim" },
+    cmd = {
+      "DiffviewOpen",
+      "DiffviewClose",
+      "DiffviewToggleFiles",
+      "DiffviewFileHistory",
+    },
+    keys = {
+      { "<leader>gm", "<cmd>DiffviewOpen<CR>", desc = "マージビューを開く" },
+      { "<leader>gq", "<cmd>DiffviewClose<CR>", desc = "マージビューを閉じる" },
+      { "<leader>gh", "<cmd>DiffviewFileHistory %<CR>", desc = "ファイル履歴" },
+    },
+    opts = {},
+  },
 }

--- a/README.md
+++ b/README.md
@@ -82,6 +82,34 @@ nvim / wezterm / starship / zsh の設定ファイルは `mkOutOfStoreSymlink` �
 
 Codex の `config.toml` は dotfiles 側のファイルが「初期テンプレ」として `~/.codex/config.toml` にコピーされます (Codex 自身が `[projects.*]` 等の実行時状態を書き込むため symlink にできない)。テンプレを更新して反映したい場合は `rm ~/.codex/config.toml && make switch` してください。
 
+## Neovim でのマージコンフリクト対応
+
+`git-conflict.nvim` と `diffview.nvim` を導入しており、以下の流れで解決できます:
+
+1. `<leader>gg` で LazyGit を開きマージ/リベースを開始
+2. コンフリクトしたファイルを開くとマーカーが自動でハイライトされる
+3. 行単位で解決する (カーソルをコンフリクトブロック内に置いて実行):
+
+   | キー | 動作 |
+   |------|------|
+   | `co` | 自分側 (ours / current) を採用 |
+   | `ct` | 相手側 (theirs / incoming) を採用 |
+   | `cb` | 両方採用 (both) |
+   | `c0` | どちらも破棄 (none) |
+   | `]x` / `[x` | 次/前のコンフリクトへ移動 |
+
+4. 文脈把握が必要な箇所は `<leader>gm` で 3-way マージビュー (`DiffviewOpen`) を開いて OURS/BASE/THEIRS を確認。`<leader>gq` で閉じる
+5. ファイル履歴を追う場合は `<leader>gh` (`DiffviewFileHistory`)
+
+補助的な Gitsigns のキーマップ (抜粋):
+
+| キー | 動作 |
+|------|------|
+| `]h` / `[h` | 次/前の hunk へ移動 |
+| `<leader>gs` / `<leader>gr` | hunk をステージ / リセット |
+| `<leader>gp` | hunk をプレビュー |
+| `<leader>gB` | 行の blame を表示 |
+
 ## API キー / シークレット
 
 `~/.config/zsh/secrets.zsh` に環境変数を export する形で管理します。


### PR DESCRIPTION
## Summary
- `git-conflict.nvim` を追加し、`co`/`ct`/`cb`/`c0` と `]x`/`[x` でコンフリクトを行単位で解決できるようにした
- `diffview.nvim` を追加し、`<leader>gm` で 3-way マージビュー、`<leader>gh` でファイル履歴を開けるようにした
- README.md にコンフリクト対応手順とキーマップ一覧を追記

## Test plan
- [x] `:Lazy sync` でプラグインがインストールされる
- [ ] 擬似コンフリクトを作成し `co`/`ct`/`cb`/`c0` と `]x`/`[x` が機能する
- [ ] `<leader>gm` で 3-way マージビューが開く / `<leader>gq` で閉じる
- [ ] 既存の gitsigns / lazygit のキーマップに影響がない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated git conflict resolution with automatic conflict marker highlighting
  * Added conflict navigation and line-level management for efficient conflict handling
  * Added 3-way merge/diff browser with keybindings: `<leader>gm` (open), `<leader>gq` (close), `<leader>gh` (file history)

* **Documentation**
  * Added comprehensive guide for handling merge conflicts in Neovim

<!-- end of auto-generated comment: release notes by coderabbit.ai -->